### PR TITLE
Improved error handling

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -60,6 +60,7 @@ virtualReadRegister	KEYWORD2
 virtualWriteRegister	KEYWORD2
 writeRegister	KEYWORD2
 readRegister	KEYWORD2
+isError KEYWORD2
 ###################################################################
 # Constants
 ###################################################################
@@ -107,3 +108,4 @@ SENSORTYPE_AS7262	LITERAL1
 SENSORTYPE_AS7263	LITERAL1
 POLLING_DELAY	LITERAL1
 _sensorVersion	LITERAL1
+_sensorError	LITERAL1

--- a/src/AS726X.h
+++ b/src/AS726X.h
@@ -13,6 +13,8 @@ class AS726X {
 public:
 	AS726X();
 	bool begin(TwoWire &wirePort = Wire, uint8_t gain = 3, uint8_t measurementMode = 3);
+	void end();
+	bool isError();
 	void takeMeasurements();
 	uint8_t getVersion();
 	void takeMeasurementsWithBulb();
@@ -126,6 +128,7 @@ private:
 #define POLLING_DELAY 5 //Amount of ms to wait between checking for virtual register changes
 
 	uint8_t _sensorVersion = 0;
+	bool _sensorError = false;
 };
 
 #endif

--- a/src/AS726X.h
+++ b/src/AS726X.h
@@ -13,7 +13,6 @@ class AS726X {
 public:
 	AS726X();
 	bool begin(TwoWire &wirePort = Wire, uint8_t gain = 3, uint8_t measurementMode = 3);
-	void end();
 	bool isError();
 	void takeMeasurements();
 	uint8_t getVersion();


### PR DESCRIPTION
Chiefly - fixes a bug where trying to read a disconnected AS726X would result in an endless loop printing "I2C Error".

Some additional error handling which is hopefully useful, although in some random circumstances of plugging/unplugging the AS726X (using a Sparkfun Artemis uC), the I2C bus is rendered useless for other devices until a complete reset.  See [https://github.com/sparkfun/Arduino_Apollo3/issues/172](url)