### PR TITLE
Fix initialization and output issues in third example code

### DIFF
--- a/examples/Example3_BulbReadings/Example3_BulbReadings.ino
+++ b/examples/Example3_BulbReadings/Example3_BulbReadings.ino
@@ -72,4 +72,6 @@ void loop() {
   Serial.print("] tempF[");
   Serial.print(sensor.getTemperatureF(), 1);
   Serial.print("]");
+
+  Serial.println();
 }

--- a/examples/Example3_BulbReadings/Example3_BulbReadings.ino
+++ b/examples/Example3_BulbReadings/Example3_BulbReadings.ino
@@ -27,13 +27,13 @@ byte GAIN = 2;
 byte MEASUREMENT_MODE = 0;
 
 void setup() {
+  Wire.begin();
+  Serial.begin(115200);
+  
   sensor.begin(Wire, GAIN, MEASUREMENT_MODE);
 }
 
 void loop() {
-  Wire.begin();
-  Serial.begin(115200);
-  
   sensor.takeMeasurementsWithBulb();
   
   if (sensor.getVersion() == SENSORTYPE_AS7262)


### PR DESCRIPTION
## Summary

Hey there👋. This pull request fixes two minor issues I encountered while testing the third example. There was no output in the serial monitor until I moved the Wire and Serial initialization away from `loop()`. After changing that, I also noticed that no newline was printed between each measurement, unlike in the other two examples.

## Changes

- Moved the initialization of Wire and Serial from `loop()` to `setup()`
- Added `Serial.println()` to end of `loop()`
